### PR TITLE
Rename edition auction

### DIFF
--- a/config/50.json
+++ b/config/50.json
@@ -1,6 +1,6 @@
 {
   "network": "mainnet",
-  "EditionsAuctionAddress": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
-  "SingleEditionMintableCreatorAddress": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
+  "dutchAuctionDropAddress": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+  "projectCreatorAddress": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
   "startBlock": 0
 }

--- a/config/80001.json
+++ b/config/80001.json
@@ -1,6 +1,6 @@
 {
   "network": "mumbai",
-  "EditionsAuctionAddress": "0xF4baA49b69EA15107d78AD097d2457cDF470E25B",
-  "SingleEditionMintableCreatorAddress": "0x9b95e22Cd51A17Eda833d5a0596a08e111F792c8",
+  "dutchAuctionDropAddress": "0xF4baA49b69EA15107d78AD097d2457cDF470E25B",
+  "projectCreatorAddress": "0x9b95e22Cd51A17Eda833d5a0596a08e111F792c8",
   "startBlock": 26335799
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -264,8 +264,8 @@ type Purchase @entity {
   "The edition purchased"
   edition: Edition!
 
-  "The Editions auction associated with the Purchase"
-  editionsAuction: EditionsAuction!
+  "The dutch auction drop associated with the Purchase"
+  dutchAuctionDrop: DutchAuctionDrop!
 
   "The amount of the Purchase"
   amount: BigInt!
@@ -309,18 +309,18 @@ type Transfer @entity {
   createdAtBlockNumber: BigInt!
 }
 
-enum EditionsAuctionStatus {
+enum DutchAuctionDropStatus {
   Pending
   Active
   Canceled
   Finished
 }
 
-type EditionsAuction @entity {
-  "ID of the editions auction from contract, autoincrementing int"
+type DutchAuctionDrop @entity {
+  "ID of the dutch auction drop from <projectContractAddress-iteration>"
   id: ID!
 
-  "Transaction hash where the editions auction was created"
+  "Transaction hash where the auction was created"
   transactionHash: String!
 
   "The project of the auction"
@@ -356,13 +356,14 @@ type EditionsAuction @entity {
   "The address of the auction's curator"
   curator: User!
 
-  # "The address of the ERC-20 currency to run the auction with, or 0x0 for ETH"
+  "The address of the ERC-20 currency to run the auction with, or 0x0 for ETH"
   auctionCurrency: Currency!
 
-  status: EditionsAuctionStatus!
+  "The current status of the auction"
+  status: DutchAuctionDropStatus!
 
   "The previous bids on this auction"
-  previousPurchases: [Purchase!]  @derivedFrom(field: "editionsAuction")
+  previousPurchases: [Purchase!]  @derivedFrom(field: "dutchAuctionDrop")
 
   "The time the auction was approved"
   approvedTimestamp: BigInt
@@ -381,6 +382,5 @@ type EditionsAuction @entity {
 
   "The block number at which the auction end function was called"
   finalizedAtBlockNumber: BigInt
-
 }
 

--- a/src/dutchAuctionDrop.ts
+++ b/src/dutchAuctionDrop.ts
@@ -3,14 +3,14 @@ import {
   AuctionApprovalUpdated,
   EditionPurchased,
   SeededEditionPurchased
-} from '../types/EditionsAuction/EditionsAuction'
+} from '../types/DutchAuctionDrop/DutchAuctionDrop'
 
 import {
-  EditionsAuction, Purchase
+  DutchAuctionDrop, Purchase
 } from '../types/schema'
 
 import {
-  createEditionsAuction,
+  createDutchAuctionDrop,
   findOrCreateCurrency,
   findOrCreateEdition,
   findOrCreateProject,
@@ -20,7 +20,7 @@ import {
 import { log } from '@graphprotocol/graph-ts'
 
 
-export function handleEditionsAuctionCreated(event: AuctionCreated): void {
+export function handleAuctionCreated(event: AuctionCreated): void {
   log.info(`Starting handler for AuctionCreated for auction {}`, [
     event.params.auctionId.toString()
   ])
@@ -31,7 +31,7 @@ export function handleEditionsAuctionCreated(event: AuctionCreated): void {
   const currency = findOrCreateCurrency(event.params.auctionCurrency.toHexString())
   const endTimestamp = event.params.startTimestamp.plus(event.params.duration)
 
-  createEditionsAuction(
+  createDutchAuctionDrop(
     event.params.auctionId.toString(),
     event.transaction.hash.toHexString(),
     project,
@@ -58,7 +58,7 @@ export function handleAuctionApprovalUpdated(event: AuctionApprovalUpdated): voi
   let id = event.params.auctionId.toString()
   log.info(`Starting handler for AuctionApprovalUpdate on auction {}`, [id])
 
-  let auction = EditionsAuction.load(id)
+  let auction = DutchAuctionDrop.load(id)
 
   if(auction == null) {
     log.error('Missing Editions Auction with id {} for approval', [id])
@@ -74,7 +74,7 @@ export function handleAuctionApprovalUpdated(event: AuctionApprovalUpdated): voi
   log.info(`Completed handler for AuctionApprovalUpdate on auction {}`, [id])
 }
 
-export function handleEditionPurchased(event: EditionPurchased): void {
+export function handleStandardEditionPurchased(event: EditionPurchased): void {
   const id = event.transaction.hash.toHexString()
   log.info(`Starting handler for EditionPurchased on auction {}`, [id])
 
@@ -95,7 +95,7 @@ export function handleSeededEditionPurchased(event: SeededEditionPurchased): voi
 function createPurchase<T extends EditionPurchased>(event: T, id: string): void {
   const auctionId = event.params.auctionId.toString()
 
-  let auction = EditionsAuction.load(auctionId)
+  let auction = DutchAuctionDrop.load(auctionId)
 
   if(auction == null) {
     log.error('Missing Editions Auction with id {} for purchase', [auctionId])
@@ -106,7 +106,7 @@ function createPurchase<T extends EditionPurchased>(event: T, id: string): void 
 
   purchase.id = id
   purchase.transactionHash = id
-  purchase.editionsAuction = auctionId
+  purchase.dutchAuctionDrop = auctionId
   purchase.amount = event.params.price
   purchase.collector = event.params.owner.toHexString()
   purchase.purchaseType = "Final"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,15 +1,12 @@
 import { Address, BigInt } from '@graphprotocol/graph-ts/index'
 
-import { ERC20 } from '../types/EditionsAuction/ERC20'
-import { ERC20NameBytes } from '../types/EditionsAuction/ERC20NameBytes'
-import { ERC20SymbolBytes } from '../types/EditionsAuction/ERC20SymbolBytes'
-
-import { SingleEditionMintable__getURIsResult } from '../types/templates/SingleEditionMintable/SingleEditionMintable'
-import { SeededSingleEditionMintable__getURIsResult } from '../types/templates/SeededSingleEditionMintable/SeededSingleEditionMintable'
+import { ERC20 } from '../types/DutchAuctionDrop/ERC20'
+import { ERC20NameBytes } from '../types/DutchAuctionDrop/ERC20NameBytes'
+import { ERC20SymbolBytes } from '../types/DutchAuctionDrop/ERC20SymbolBytes'
 
 import {
   User,
-  EditionsAuction,
+  DutchAuctionDrop,
   Currency,
   Edition,
   Project,
@@ -19,8 +16,6 @@ import {
   Transfer,
   ProjectMinterApproval
 } from '../types/schema'
-
-import { ethereum } from '@graphprotocol/graph-ts/index'
 
 export const zeroAddress = '0x0000000000000000000000000000000000000000'
 /**
@@ -127,7 +122,7 @@ export function findOrCreateProjectMinterApproval(id: string): ProjectMinterAppr
   return projectMinterApproval as ProjectMinterApproval
 }
 
-export function createEditionsAuction(
+export function createDutchAuctionDrop(
   id: string,
   transactionHash: string,
   project: Project,
@@ -143,31 +138,31 @@ export function createEditionsAuction(
   createdAtBlockNumber: BigInt,
   creator: User,
   curator: User
-): EditionsAuction {
-  let editionsAuction = new EditionsAuction(id)
+): DutchAuctionDrop {
+  let auction = new DutchAuctionDrop(id)
 
-  editionsAuction.id = id
-  editionsAuction.transactionHash = transactionHash
-  editionsAuction.project = project.id
-  editionsAuction.approved = false
-  editionsAuction.duration = duration
-  editionsAuction.startTimestamp = startTimestamp
-  editionsAuction.endTimestamp = endTimestamp
-  editionsAuction.startPrice = startPrice
-  editionsAuction.endPrice = endPrice
-  editionsAuction.numberOfPriceDrops = numberOfPriceDrops
-  editionsAuction.approvedTimestamp = null
-  editionsAuction.curatorRoyaltyBPS = curatorRoyaltyBPS
-  editionsAuction.creator = creator.id
-  editionsAuction.curator = curator.id
-  editionsAuction.auctionCurrency = auctionCurrency.id
-  editionsAuction.status = 'Pending'
-  editionsAuction.createdAtTimestamp = createdAtTimestamp
-  editionsAuction.createdAtBlockNumber = createdAtBlockNumber
+  auction.id = id
+  auction.transactionHash = transactionHash
+  auction.project = project.id
+  auction.approved = false
+  auction.duration = duration
+  auction.startTimestamp = startTimestamp
+  auction.endTimestamp = endTimestamp
+  auction.startPrice = startPrice
+  auction.endPrice = endPrice
+  auction.numberOfPriceDrops = numberOfPriceDrops
+  auction.approvedTimestamp = null
+  auction.curatorRoyaltyBPS = curatorRoyaltyBPS
+  auction.creator = creator.id
+  auction.curator = curator.id
+  auction.auctionCurrency = auctionCurrency.id
+  auction.status = 'Pending'
+  auction.createdAtTimestamp = createdAtTimestamp
+  auction.createdAtBlockNumber = createdAtBlockNumber
 
-  editionsAuction.save()
+  auction.save()
 
-  return editionsAuction
+  return auction
 }
 
 /**

--- a/src/mappings/projectCreator.ts
+++ b/src/mappings/projectCreator.ts
@@ -1,10 +1,10 @@
 import {
-  SingleEditionMintable,
-  SeededSingleEditionMintable
+  StandardProject,
+  SeededProject
 } from '../../types/templates'
 import {
   CreatedEdition,
-} from '../../types/SingleEditionMintableCreator/SingleEditionMintableCreator'
+} from '../../types/ProjectCreator/ProjectCreator'
 import {
   findOrCreateProject,
   findOrCreateUser
@@ -25,13 +25,13 @@ export function handleCreatedProject (event: CreatedEdition): void {
   // create mapping with context based on project implementation
 
   if(projectImplementations[event.params.implementation] == "Standard") {
-    SingleEditionMintable.createWithContext(
+    StandardProject.createWithContext(
       event.params.editionContractAddress,
       context
     )
   }
   if(projectImplementations[event.params.implementation] == "Seeded") {
-    SeededSingleEditionMintable.createWithContext(
+    SeededProject.createWithContext(
       event.params.editionContractAddress,
       context
     )

--- a/src/projectHandlers.ts
+++ b/src/projectHandlers.ts
@@ -1,17 +1,17 @@
 // Edition handlers
 import {
   Transfer,
-  SingleEditionMintable as SingleEditionMintableContract,
+  StandardProject,
   VersionAdded,
   VersionURLUpdated,
   Approval,
   ApprovedMinter,
   RoyaltyFundsRecipientChanged,
-} from '../types/templates/SingleEditionMintable/SingleEditionMintable'
+} from '../types/templates/StandardProject/StandardProject'
 
 import {
-  SeededSingleEditionMintable,
-} from '../types/templates/SeededSingleEditionMintable/SeededSingleEditionMintable'
+  SeededProject,
+} from '../types/templates/SeededProject/SeededProject'
 
 import {
   Purchase,
@@ -113,14 +113,14 @@ function mintHandler<T extends Transfer>(event: T, context: DataSourceContext): 
   let projectAddress = Address.fromString(context.getString('project'))
 
   if(project.implementation == "Standard"){
-    let singleEditionMintable = SingleEditionMintableContract.bind(projectAddress)
-    edition.uri = singleEditionMintable.tokenURI(event.params.tokenId)
+    let standardProject = StandardProject.bind(projectAddress)
+    edition.uri = standardProject.tokenURI(event.params.tokenId)
   }
 
   if(project.implementation == "Seeded"){
-    let seededSingleEditionMintable = SeededSingleEditionMintable.bind(projectAddress)
-    edition.uri = seededSingleEditionMintable.tokenURI(event.params.tokenId)
-    edition.seed = seededSingleEditionMintable.seedOfTokens(event.params.tokenId)
+    let seededProject = SeededProject.bind(projectAddress)
+    edition.uri = seededProject.tokenURI(event.params.tokenId)
+    edition.seed = seededProject.seedOfTokens(event.params.tokenId)
   }
 
   edition.save()
@@ -209,16 +209,16 @@ export function versionAddedHandler<T extends VersionAdded>(event: T, context: D
 
   if(project.implementation == "Standard") {
      // call getURIs of version to fetch uris for specifc for label
-    const singleEditionMintableContract = SingleEditionMintableContract.bind(
+    const standardProject = StandardProject.bind(
       Address.fromString(projectAddress)
     )
 
     // HACK(george): running into a type mismatch error with the following
-    // const callResult = singleEditionMintableContract.try_getURIsOfVersion(event.params.label)
+    // const callResult = standardProject.try_getURIsOfVersion(event.params.label)
     // TODO: try this https://www.assemblyscript.org/stdlib/staticarray.html
     // my solution for now is to call getURIs as it will retrieve latest added URIs
     // it is "unlikley" versions to be updated in quick succsession.
-    const callResult = singleEditionMintableContract.try_getURIs()
+    const callResult = standardProject.try_getURIs()
     if(callResult.reverted){
       log.info("getURIs Reverted", [])
       // TODO: need to add urlHashes
@@ -227,10 +227,10 @@ export function versionAddedHandler<T extends VersionAdded>(event: T, context: D
 
     // handle project initialization
     if(!project.lastAddedVersion){
-      project.name = singleEditionMintableContract.name()
-      project.symbol = singleEditionMintableContract.symbol()
-      project.description = singleEditionMintableContract.description()
-      project.royaltyBPS = singleEditionMintableContract.royaltyBPS()
+      project.name = standardProject.name()
+      project.symbol = standardProject.symbol()
+      project.description = standardProject.description()
+      project.royaltyBPS = standardProject.royaltyBPS()
     }
 
     // update latest versions
@@ -255,12 +255,12 @@ export function versionAddedHandler<T extends VersionAdded>(event: T, context: D
 
   if(project.implementation == "Seeded"){
     // call getURIs of version to fetch uris for specifc for label
-    const seededSingleEditionMintable = SeededSingleEditionMintable.bind(
+    const seededProject = SeededProject.bind(
       Address.fromString(projectAddress)
     )
 
     // HACK(george): same hack as used above for singlineEditionMintable
-    const callResult = seededSingleEditionMintable.try_getURIs()
+    const callResult = seededProject.try_getURIs()
     if(callResult.reverted){
       log.info("getURIs Reverted", [])
       // TODO: need to add urlHashes
@@ -269,10 +269,10 @@ export function versionAddedHandler<T extends VersionAdded>(event: T, context: D
 
     // handle project initialization
     if(!project.lastAddedVersion){
-      project.name = seededSingleEditionMintable.name()
-      project.symbol = seededSingleEditionMintable.symbol()
-      project.description = seededSingleEditionMintable.description()
-      project.royaltyBPS = seededSingleEditionMintable.royaltyBPS()
+      project.name = seededProject.name()
+      project.symbol = seededProject.symbol()
+      project.description = seededProject.description()
+      project.royaltyBPS = seededProject.royaltyBPS()
     }
 
     // update latest versions

--- a/src/projectHandlers.ts
+++ b/src/projectHandlers.ts
@@ -329,8 +329,12 @@ export function royaltyFundsRecipientChangedHandler<T extends RoyaltyFundsRecipi
   const projectId = context.getString('project')
 
   log.info(`Starting: handler for royaltyFundsRecipientChanged for project {}`, [projectId])
+
+  let newRecipient = findOrCreateUser(event.params.newRecipientAddress.toHexString())
+
   let project = findOrCreateProject(projectId)
-  project.royaltyRecpient = event.params.newRecipientAddress.toHexString()
+  project.royaltyRecpient = newRecipient.id
   project.save()
+
   log.info(`Completed: handler for royaltyFundsRecipientChanged for project {}`, [projectId])
 }

--- a/src/seededProject.ts
+++ b/src/seededProject.ts
@@ -7,7 +7,7 @@ import {
   Approval,
   ApprovedMinter,
   RoyaltyFundsRecipientChanged
-} from '../types/templates/SeededSingleEditionMintable/SeededSingleEditionMintable'
+} from '../types/templates/SeededProject/SeededProject'
 
 import {
   approvedMinterHandler,

--- a/src/standardProject.ts
+++ b/src/standardProject.ts
@@ -7,7 +7,7 @@ import {
   Approval,
   ApprovedMinter,
   RoyaltyFundsRecipientChanged
-} from '../types/templates/SingleEditionMintable/SingleEditionMintable'
+} from '../types/templates/StandardProject/StandardProject'
 
 import {
   approvedMinterHandler,

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -5,21 +5,21 @@ schema:
   file: ./schema.graphql
 dataSources:
   - kind: ethereum/contract
-    name: EditionsAuction
+    name: DutchAuctionDrop
     network: {{ network }}
     source:
-      address: "{{ EditionsAuctionAddress }}"
-      abi: EditionsAuction
+      address: "{{ dutchAuctionDropAddress }}"
+      abi: DutchAuctionDrop
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5
       language: wasm/assemblyscript
       entities:
-        - EditionsAuction
+        - DutchAuctionDrop
         - Purchase
       abis:
-        - name: EditionsAuction
+        - name: DutchAuctionDrop
           file: ./deployments/localhost/EditionsAuction.json
         - name: ERC20
           file: ./abis/ERC20/ERC20.json
@@ -29,20 +29,20 @@ dataSources:
           file: ./abis/ERC20/ERC20NameBytes.json
       eventHandlers:
         - event: AuctionCreated(uint256,address,(address,uint8),uint256,uint256,uint256,uint256,uint8,address,uint256,address)
-          handler: handleEditionsAuctionCreated
+          handler: handleAuctionCreated
         - event: EditionPurchased(uint256,address,uint256,uint256,address)
-          handler: handleEditionPurchased
+          handler: handleStandardEditionPurchased
         - event: SeededEditionPurchased(uint256,address,uint256,uint256,uint256,address)
           handler: handleSeededEditionPurchased
         - event: AuctionApprovalUpdated(uint256,address,bool)
           handler: handleAuctionApprovalUpdated
-      file: ./src/auction.ts
+      file: ./src/dutchAuctionDrop.ts
   - kind: ethereum/contract
-    name: SingleEditionMintableCreator
+    name: ProjectCreator
     network: {{ network }}
     source:
-      address: "{{ SingleEditionMintableCreatorAddress }}"
-      abi: SingleEditionMintableCreator
+      address: "{{ projectCreatorAddress }}"
+      abi: ProjectCreator
       startBlock: {{ startBlock }}
     mapping:
       kind: ethereum/events
@@ -50,7 +50,7 @@ dataSources:
       language: wasm/assemblyscript
       file: ./src/mappings/projectCreator.ts
       abis:
-        - name: SingleEditionMintableCreator
+        - name: ProjectCreator
           file: ./deployments/localhost/SingleEditionMintableCreator.json
       entities:
         - ProjectCreator
@@ -58,11 +58,11 @@ dataSources:
         - event: CreatedEdition(indexed uint256,indexed address,uint256,address,uint8)
           handler: handleCreatedProject
 templates:
-  - name: SingleEditionMintable
+  - name: StandardProject
     kind: ethereum/contract
     network: {{ network }}
     source:
-      abi: SingleEditionMintable
+      abi: StandardProject
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5
@@ -75,7 +75,7 @@ templates:
         - UrlHashPair
         - UrlUpdate
       abis:
-        - name: SingleEditionMintable
+        - name: StandardProject
           file: ./deployments/localhost/SingleEditionMintable.json
       eventHandlers:
         - event: Approval(indexed address,indexed address,indexed uint256)
@@ -93,11 +93,11 @@ templates:
         # TODO: set price sale eth
         # TODO: other erc-721 events
       file: ./src/standardProject.ts
-  - name: SeededSingleEditionMintable
+  - name: SeededProject
     kind: ethereum/contract
     network: {{ network }}
     source:
-      abi: SeededSingleEditionMintable
+      abi: SeededProject
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5
@@ -110,7 +110,7 @@ templates:
         - UrlHashPair
         - UrlUpdate
       abis:
-        - name: SeededSingleEditionMintable
+        - name: SeededProject
           file: ./deployments/localhost/SeededSingleEditionMintable.json
       eventHandlers:
         - event: Approval(indexed address,indexed address,indexed uint256)


### PR DESCRIPTION
resolves #19 

renames `editionsAuction` -> `dutchAuctionDrop`

also updates the names in `subgraph.template.yaml` so new names are used everywhere except from the src's and in the scripts folder

fixes bug where royaltyRecpient was not being indexed if user did not exist