### PR TITLE
Index user type splits

### DIFF
--- a/abis/0xSplits/SplitMain.json
+++ b/abis/0xSplits/SplitMain.json
@@ -1,0 +1,21 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "split",
+        "type": "address"
+      }
+    ],
+    "name": "getHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/abis/0xSplits/SplitWallet.json
+++ b/abis/0xSplits/SplitWallet.json
@@ -1,0 +1,15 @@
+[
+  {
+    "inputs": [],
+    "name": "splitMain",
+    "outputs": [
+      {
+        "internalType": "contract ISplitMain",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/schema.graphql
+++ b/schema.graphql
@@ -252,6 +252,13 @@ type Currency @entity {
   previousPurchases: [Purchase!] @derivedFrom(field: "currency")
 }
 
+enum UserType {
+  "Externally Owned Address"
+  EOA
+  "0xSplits Smart contract"
+  SplitWallet
+}
+
 type User @entity {
   "Ethereum Address"
   id: ID!
@@ -283,6 +290,9 @@ type User @entity {
 
   "The approval status of the users ability to create projects"
   curatedCreator: Boolean!
+
+  "The type of User, needs to be verified"
+  type: UserType!
 }
 
 enum PurchaseType {

--- a/scripts/createSplit.ts
+++ b/scripts/createSplit.ts
@@ -1,0 +1,322 @@
+/* This script is used to create a 0xSplits wallet for testing
+
+   Before running:
+   - clone https://github.com/0xSplits/splits-contracts
+   - deploy SplitMain with:
+      yarn run hardhat deploy --network localhost
+   - note address and change SplitMainAddress below if needed
+
+   To run this script:
+      yarn hardhat run --network localhost scripts/createSplit.ts
+
+  if all goes well it will log an address which can be copied to
+  splitWalletAddress in ./seed.ts
+*/
+
+import { Contract } from "ethers"
+import { ethers } from "hardhat"
+
+// change this if needed
+const SplitMainAddress = "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+
+const scale = ethers.BigNumber.from(1e6).toNumber() / 100
+const percent = (num: number) => num * scale
+
+// creates a determined split
+const getSplit = async () => {
+  const addresses = (await ethers.getSigners()).slice(0, 3).map(s => s.address)
+  addresses.sort((a, b) => {
+    if (a.toLowerCase() > b.toLowerCase()) return 1
+    return -1
+  })
+
+  return {
+    addresses,
+    percentAllocations: [
+      percent(10),
+      percent(20),
+      percent(70)
+    ],
+    distributorFee: percent(1),
+    controller: ethers.constants.AddressZero
+  }
+}
+
+getSplitWallet()
+
+async function getSplitWallet() {
+  const [signer] = await ethers.getSigners()
+
+  // get contract
+  const SplitMain = new ethers.Contract(
+    SplitMainAddress,
+    SplitMainABI,
+    signer
+  )
+
+  const split = await getSplit()
+
+  try {
+    // check if split wallet already created
+    const splitAddress = await SplitMain.predictImmutableSplitAddress(
+      split.addresses,
+      split.percentAllocations,
+      split.distributorFee,
+    )
+
+    const hash = await SplitMain.getHash(splitAddress)
+
+    if(hash === ethers.constants.AddressZero){
+      console.log("No split wallet found")
+      await createSplit(SplitMain)
+    }
+
+    console.log("SplitWallet", splitAddress)
+    return splitAddress
+
+  } catch (error: any) {
+    if(error?.code === "CALL_EXCEPTION"){
+      console.log("MAKE SURE YOU'VE DEPLOYED 0xSplits")
+      return
+    }
+
+    console.error(error)
+  }
+}
+
+async function createSplit(SplitMain: Contract){
+
+  const split = await getSplit()
+
+  try{
+    // create split
+    const tx = await SplitMain.createSplit(
+      split.addresses,
+      split.percentAllocations,
+      split.distributorFee,
+      split.controller
+    )
+    const receipt = await tx.wait()
+
+    // parse event logs
+    const {name, args} = SplitMain.interface.parseLog(receipt.logs[0])
+    console.log("success", name, args[0])
+
+  } catch (error: any) {
+    // parse errors
+    console.log(SplitMain.interface.parseError(error.data.data))
+  }
+}
+
+// taken selected bits from SplitMain.json
+var SplitMainABI = JSON.parse(`[
+  {
+    "inputs": [],
+    "name": "Create2Error",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CreateError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newController",
+        "type": "address"
+      }
+    ],
+    "name": "InvalidNewController",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountsLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "allocationsLength",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidSplit__AccountsAndAllocationsMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidSplit__AccountsOutOfOrder",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidSplit__AllocationMustBePositive",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "allocationsSum",
+        "type": "uint32"
+      }
+    ],
+    "name": "InvalidSplit__InvalidAllocationsSum",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "distributorFee",
+        "type": "uint32"
+      }
+    ],
+    "name": "InvalidSplit__InvalidDistributorFee",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "hash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "InvalidSplit__InvalidHash",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountsLength",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidSplit__TooFewAccounts",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "split",
+        "type": "address"
+      }
+    ],
+    "name": "CreateSplit",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "accounts",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "percentAllocations",
+        "type": "uint32[]"
+      },
+      {
+        "internalType": "uint32",
+        "name": "distributorFee",
+        "type": "uint32"
+      }
+    ],
+    "name": "predictImmutableSplitAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "split",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "accounts",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "percentAllocations",
+        "type": "uint32[]"
+      },
+      {
+        "internalType": "uint32",
+        "name": "distributorFee",
+        "type": "uint32"
+      },
+      {
+        "internalType": "address",
+        "name": "controller",
+        "type": "address"
+      }
+    ],
+    "name": "createSplit",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "split",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "split",
+        "type": "address"
+      }
+    ],
+    "name": "getHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]`)

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -19,9 +19,9 @@ import { BigNumberish, ContractTransaction } from "ethers";
 
 type Label = [BigNumberish, BigNumberish, BigNumberish]
 
-// const DutchAuctionDropAddress = "0x5FbDB2315678afecb367f032d93F642f64180aa3"
-// const ProjectCreatorAddress = "0x0165878A594ca255338adfa4d48449f69242Eb8F"
-// const WETHaddress ="0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+// change this to test 0xSplits wallet as royalty fund recipient
+// See ./createSplit.ts
+const SplitWalletAddress = ""
 
 const mineOneHour = async () => {
   await network.provider.send("evm_increaseTime", [3600])
@@ -348,8 +348,13 @@ const run = async () => {
   console.log(`${count.increment()} collector purchased seeded NFT seed(5)`, tx.hash)
 
   // change royalty fund recipient
-  await SeededProject.connect(creator).setRoyaltyFundsRecipient(curator.address)
-  console.log(`${count.increment()} creator set royalty fund recipient to curator`, tx.hash)
+  if(SplitWalletAddress.length){
+    await SeededProject.connect(creator).setRoyaltyFundsRecipient(SplitWalletAddress)
+    console.log(`${count.increment()} creator set royalty fund recipient to 0xSplits Wallet`, tx.hash)
+  } else {
+    await SeededProject.connect(creator).setRoyaltyFundsRecipient(curator.address)
+    console.log(`${count.increment()} creator set royalty fund recipient to curator`, tx.hash)
+  }
 
   // mine an hour in time
   // NOTE[george]: this is a precution if the seed script has already been run

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -36,6 +36,7 @@ export function findOrCreateUser(id: string): User {
 
   if (user == null) {
     user = new User(id)
+    user.type = "EOA"
     user.save()
   }
 

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -99,6 +99,10 @@ templates:
       abis:
         - name: StandardProject
           file: ./deployments/localhost/StandardProject.json
+        - name: SplitMain
+          file: ./abis/0xSplits/SplitMain.json
+        - name: SplitWallet
+          file: ./abis/0xSplits/SplitWallet.json
       eventHandlers:
         - event: Approval(indexed address,indexed address,indexed uint256)
           handler: handleApproval
@@ -134,6 +138,10 @@ templates:
       abis:
         - name: SeededProject
           file: ./deployments/localhost/SeededProject.json
+        - name: SplitMain
+          file: ./abis/0xSplits/SplitMain.json
+        - name: SplitWallet
+          file: ./abis/0xSplits/SplitWallet.json
       eventHandlers:
         - event: Approval(indexed address,indexed address,indexed uint256)
           handler: handleApproval


### PR DESCRIPTION
Adds type property to user.
By default it is set to "EOA" *(externally owned address)*
```graphql
@entitiy User {
 type : "EOA" | "SplitWallet"
}
```

It is set to "SplitWallet" when the royalty recipient is changed on the project and the `splitMain` property can be read. It's not concrete but meant to be helpful on the front-end to then query 0xSplits subgraph if needed.

Also adds a helper script for testing locally `scripts/createSplit.ts` requires 0xSplit contracts to be deployed on hardhat node.

resolves #29 #30