### PR TITLE
Asks

### DIFF
--- a/abis/Zora/AsksV1_1.json
+++ b/abis/Zora/AsksV1_1.json
@@ -1,0 +1,609 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_erc20TransferHelper",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_erc721TransferHelper",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_royaltyEngine",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_protocolFeeSettings",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_wethAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "tokenContract",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "seller",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sellerFundsRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "askCurrency",
+            "type": "address"
+          },
+          {
+            "internalType": "uint16",
+            "name": "findersFeeBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint256",
+            "name": "askPrice",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct AsksV1_1.Ask",
+        "name": "ask",
+        "type": "tuple"
+      }
+    ],
+    "name": "AskCanceled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "tokenContract",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "seller",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sellerFundsRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "askCurrency",
+            "type": "address"
+          },
+          {
+            "internalType": "uint16",
+            "name": "findersFeeBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint256",
+            "name": "askPrice",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct AsksV1_1.Ask",
+        "name": "ask",
+        "type": "tuple"
+      }
+    ],
+    "name": "AskCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "tokenContract",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "buyer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "finder",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "seller",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sellerFundsRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "askCurrency",
+            "type": "address"
+          },
+          {
+            "internalType": "uint16",
+            "name": "findersFeeBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint256",
+            "name": "askPrice",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct AsksV1_1.Ask",
+        "name": "ask",
+        "type": "tuple"
+      }
+    ],
+    "name": "AskFilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "tokenContract",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "seller",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "sellerFundsRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "askCurrency",
+            "type": "address"
+          },
+          {
+            "internalType": "uint16",
+            "name": "findersFeeBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint256",
+            "name": "askPrice",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct AsksV1_1.Ask",
+        "name": "ask",
+        "type": "tuple"
+      }
+    ],
+    "name": "AskPriceUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "userA",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "userB",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "tokenContract",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct UniversalExchangeEventV1.ExchangeDetails",
+        "name": "a",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "tokenContract",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct UniversalExchangeEventV1.ExchangeDetails",
+        "name": "b",
+        "type": "tuple"
+      }
+    ],
+    "name": "ExchangeExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "tokenContract",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RoyaltyPayout",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenContract",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_payoutCurrency",
+        "type": "address"
+      }
+    ],
+    "name": "_handleRoyaltyEnginePayout",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "askForNFT",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "sellerFundsRecipient",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "askCurrency",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "findersFeeBps",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint256",
+        "name": "askPrice",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenContract",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancelAsk",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenContract",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_askPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_askCurrency",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_sellerFundsRecipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_findersFeeBps",
+        "type": "uint16"
+      }
+    ],
+    "name": "createAsk",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "erc20TransferHelper",
+    "outputs": [
+      {
+        "internalType": "contract ERC20TransferHelper",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "erc721TransferHelper",
+    "outputs": [
+      {
+        "internalType": "contract ERC721TransferHelper",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenContract",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_fillCurrency",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_fillAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_finder",
+        "type": "address"
+      }
+    ],
+    "name": "fillAsk",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "registrar",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenContract",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_askPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_askCurrency",
+        "type": "address"
+      }
+    ],
+    "name": "setAskPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_royaltyEngine",
+        "type": "address"
+      }
+    ],
+    "name": "setRoyaltyEngineAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/Zora/ERC20TransferHelper.json
+++ b/abis/Zora/ERC20TransferHelper.json
@@ -1,0 +1,73 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_approvalsManager",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "ZMM",
+    "outputs": [
+      {
+        "internalType": "contract ZoraModuleManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "isModuleApproved",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/Zora/ERC721TransferHelper.json
+++ b/abis/Zora/ERC721TransferHelper.json
@@ -1,0 +1,101 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_approvalsManager",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "ZMM",
+    "outputs": [
+      {
+        "internalType": "contract ZoraModuleManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "isModuleApproved",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/Zora/ModuleManager.json
+++ b/abis/Zora/ModuleManager.json
@@ -1,0 +1,286 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_registrar",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_feeToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "module",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ModuleApprovalSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "module",
+        "type": "address"
+      }
+    ],
+    "name": "ModuleRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newRegistrar",
+        "type": "address"
+      }
+    ],
+    "name": "RegistrarChanged",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_module",
+        "type": "address"
+      }
+    ],
+    "name": "isModuleApproved",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "moduleFeeToken",
+    "outputs": [
+      {
+        "internalType": "contract ZoraProtocolFeeSettings",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "moduleRegistered",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_module",
+        "type": "address"
+      }
+    ],
+    "name": "registerModule",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "registrar",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_module",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForModule",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_module",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_approved",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "_v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "setApprovalForModuleBySig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_modules",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "_approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setBatchApprovalForModules",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_registrar",
+        "type": "address"
+      }
+    ],
+    "name": "setRegistrar",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "sigNonces",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "userApprovals",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/config/137.json
+++ b/config/137.json
@@ -3,5 +3,6 @@
   "dutchAuctionDropAddress": "0xfd63d938F82C94a30D940475f572ec10214ed907",
   "projectCreatorAddress": "0x17F92AE6d8770CE4Ee689f188Bcc83e1Ab1e58d4",
   "profilesAddress": "0x1acde240D4990CBD97DC60D7E36fE254b16ea569",
+  "zoraAsksAddress": "0x3634e984Ba0373Cfa178986FD19F03ba4dD8E469",
   "startBlock": 30941600
 }

--- a/config/50.json
+++ b/config/50.json
@@ -3,5 +3,6 @@
   "dutchAuctionDropAddress": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
   "projectCreatorAddress": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
   "profilesAddress": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
+  "zoraAsksAddress": "0x4c5859f0F772848b2D91F1D83E2Fe57935348029",
   "startBlock": 0
 }

--- a/config/80001.json
+++ b/config/80001.json
@@ -3,5 +3,6 @@
   "dutchAuctionDropAddress": "0x57D9b13B8f5fFA5ba2002891001aBF33FCc4601b",
   "projectCreatorAddress": "0x0bEc046DDbA18894088Bf4130AbD8496b8dff154",
   "profilesAddress": "0x485210cd4205a658EAf35072b07032fE583756Fb",
+  "zoraAsksAddress": "0xCe6cEf2A9028e1C3B21647ae3B4251038109f42a",
   "startBlock": 27029146
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -32,7 +32,8 @@ const config: HardhatUserConfig = {
     target: 'ethers-v5',
     alwaysGenerateOverloads: false, // should overloads with full signatures like deposit(uint256) be generated always, even if there are no overloads?
     externalArtifacts: [
-      "./deployments/localhost/*.json"
+      "./deployments/localhost/*.json",
+      "./abis/Zora/*.json"
     ]
   },
   external: {

--- a/schema.graphql
+++ b/schema.graphql
@@ -377,7 +377,7 @@ enum AskStatus {
 }
 
 type Ask @entity {
-  "<txHash>"
+  "<projectSmartContractAddress>-<editionId> if filled <projectSmartContractAddress>-<editionId>-<txHash>"
   id: ID!
 
   "The edition the ask is for"

--- a/schema.graphql
+++ b/schema.graphql
@@ -371,6 +371,43 @@ type Transfer @entity {
   createdAtBlockNumber: BigInt!
 }
 
+enum AskStatus {
+  Active
+  Filled
+}
+
+type Ask @entity {
+  "<txHash>"
+  id: ID!
+
+  "The edition the ask is for"
+  edition: Edition!
+
+  "The current asking price"
+  price: BigInt!
+
+  "The Currency the purchase was made in"
+  currency: Currency!
+
+  "The status of the ask 'Active' or 'Filled'"
+  status: AskStatus!
+
+  "The user that filled the ask, null if not filled"
+  collector: User
+
+  "The timestamp of the block the Ask was created in"
+  createdAtTimestamp: BigInt!
+
+  "The number of the block the Ask was created in"
+  createdAtBlockNumber: BigInt!
+
+  "The timestamp of the block the Ask was filled in"
+  filledAtTimestamp: BigInt!
+
+  "The number of the block the Ask was filled in"
+  filledAtBlockNumber: BigInt!
+}
+
 enum DutchAuctionDropStatus {
   Pending
   Active

--- a/scripts/zoraAsks.ts
+++ b/scripts/zoraAsks.ts
@@ -1,0 +1,138 @@
+/* This script is used to create an Ask using zora v3
+
+   before running you must deploy Zora/v3 to local hardhat node.
+   This is quite tricky as they used foundry and have left out certain deployment scripts
+   in the repo.
+
+   contact @george if this is required
+*/
+
+import { Contract } from "ethers"
+import { ethers } from "hardhat"
+import AsksAbi from "../abis/Zora/AsksV1_1.json"
+// import ERC721TransferHelperAbi from "../abis/Zora/ERC721TransferHelper.json"
+// import ERC20TransferHelperAbi from "../abis/Zora/ERC20TransferHelper.json"
+import ModuleManagerAbi from "../abis/Zora/ModuleManager.json"
+
+import {
+   StandardProject,
+   StandardProject__factory,
+   WETH,
+   WETH__factory,
+ } from "../typechain"
+
+// change this if needed
+const AsksAddress = "0x4c5859f0F772848b2D91F1D83E2Fe57935348029"
+const WETHAddress = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+const ERC721TransferHelperAddress = "0x8f86403A4DE0BB5791fa46B8e795C547942fE4Cf"
+const ERC20TransferHelperAddress = "0x9d4454B023096f34B160D6B654540c56A1F81688"
+const ModuleManagerAddress = "0x998abeb3E57409262aE5b751f60747921B33613E"
+
+const projectAddress = "0x4616114E122385d12390fe3995957469C90998Be"
+
+const run = async () => {
+   // Signers
+   const [curator, creator, collector, ] = await ethers.getSigners()
+   console.log(curator.address, creator.address, collector.address)
+
+   // Contracts
+   const Project = (await ethers.getContractAt(
+      StandardProject__factory.abi,
+      projectAddress
+   )) as StandardProject;
+   const WETH = (await ethers.getContractAt(
+      WETH__factory.abi,
+      WETHAddress
+   )) as WETH
+   const Asks = new ethers.Contract(
+      AsksAddress,
+      AsksAbi
+   )
+   const ModuleManager = new ethers.Contract(
+      ModuleManagerAddress,
+      ModuleManagerAbi
+   )
+
+   try{
+      await ModuleManager.connect(curator).registerModule(AsksAddress)
+   } catch (e) {
+      console.log("asks module already registered :) ... maybe")
+   }
+
+
+   // approvals
+   await Project.connect(collector).setApprovalForAll(ERC721TransferHelperAddress, true)
+   await ModuleManager.connect(collector).setApprovalForModule(AsksAddress, true)
+
+
+   try{
+      // ask
+      await Asks.connect(collector).createAsk(
+         projectAddress,
+         1,
+         ethers.utils.parseEther("0.1"),
+         WETHAddress,
+         collector.address,
+         2500
+      )
+      console.log("SUCCESS", "ask created")
+
+      // update
+      await Asks.connect(collector).setAskPrice(
+         projectAddress,
+         1,
+         ethers.utils.parseEther("0.5"),
+         WETHAddress
+      )
+      console.log("SUCCESS", "ask updated")
+
+      // cancel
+      await Asks.connect(collector).cancelAsk(
+         projectAddress,
+         1
+      )
+      console.log("SUCCESS", "ask canceled")
+
+      // create again
+      await Asks.connect(collector).createAsk(
+         projectAddress,
+         1,
+         ethers.utils.parseEther("0.1"),
+         WETHAddress,
+         collector.address,
+         2500
+      )
+
+      // Fill Ask
+
+      // get some WETH
+      const allowance = await WETH.allowance(curator.address, ERC20TransferHelperAddress)
+      if(allowance.lt(ethers.utils.parseEther("0.1"))){
+         await WETH.connect(curator).deposit({ value: ethers.utils.parseEther("10.0") });
+      }
+
+      // approve erc-20
+      await WETH.connect(curator).approve(ERC20TransferHelperAddress, ethers.constants.MaxUint256);
+
+      // approve asks module
+      await ModuleManager.connect(curator).setApprovalForModule(AsksAddress, true)
+
+      // fill
+      await Asks.connect(curator).fillAsk(
+         projectAddress,
+         1,
+         WETHAddress,
+         ethers.utils.parseEther("0.1"),
+         curator.address
+      )
+
+      console.log("success: ask filled")
+
+
+   } catch (e) {
+      console.error("ERROR", e)
+   }
+}
+
+run()
+

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -16,7 +16,8 @@ import {
   UrlUpdate,
   Transfer,
   ProjectMinterApproval,
-  ProjectCreator
+  ProjectCreator,
+  Ask
 } from '../types/schema'
 
 export const zeroAddress = '0x0000000000000000000000000000000000000000'
@@ -134,6 +135,17 @@ export function findOrCreateTransfer(id: string): Transfer {
   }
 
   return transfer as Transfer
+}
+
+export function findOrCreateAsk(id: string): Ask {
+  let ask = Ask.load(id)
+
+  if(ask == null){
+    ask = new Ask(id)
+    ask.save()
+  }
+
+  return ask as Ask
 }
 
 export function findOrCreateProjectMinterApproval(id: string): ProjectMinterApproval {

--- a/src/zoraAsks.ts
+++ b/src/zoraAsks.ts
@@ -1,0 +1,33 @@
+import {AskCreated, AskPriceUpdated, AskCanceled, AskFilled} from "../types/AsksV1_1/AsksV1_1"
+import { findOrCreateAsk, findOrCreateCurrency, findOrCreateEdition } from "./helpers"
+import { log } from '@graphprotocol/graph-ts'
+import { Edition } from "../types/schema"
+
+export function handleAskCreated (event: AskCreated):void {
+
+  // check nft is an olta edition
+  const edition = Edition.load(`${event.params.tokenContract.toHexString()}-${event.params.tokenId.toString()}`)
+  if(edition === null) {
+    return
+  }
+
+  let id = event.transaction.hash.toHexString()
+  log.info(`Starting handler for AskCreated {}`, [id])
+
+  const ask = findOrCreateAsk(id)
+  const currency = findOrCreateCurrency(event.params.ask.askCurrency.toHexString())
+
+  ask.price = event.params.ask.askPrice
+  ask.currency = currency.id
+  ask.edition = edition.id
+  ask.status = "Active"
+  ask.createdAtTimestamp = event.block.timestamp
+  ask.createdAtBlockNumber = event.block.number
+
+  ask.save()
+
+  log.info(`Completed handler for AskCreated {}`, [id])
+}
+export function handleAskPriceUpdated (event: AskPriceUpdated):void {}
+export function handleAskCanceled (event: AskCanceled):void {}
+export function handleAskFilled (event: AskFilled):void {}

--- a/src/zoraAsks.ts
+++ b/src/zoraAsks.ts
@@ -1,21 +1,21 @@
 import {AskCreated, AskPriceUpdated, AskCanceled, AskFilled} from "../types/AsksV1_1/AsksV1_1"
-import { findOrCreateAsk, findOrCreateCurrency, findOrCreateEdition } from "./helpers"
-import { log } from '@graphprotocol/graph-ts'
-import { Edition } from "../types/schema"
+import { findOrCreateAsk, findOrCreateCurrency, findOrCreateEdition, findOrCreateUser } from "./helpers"
+import { log, crypto, ByteArray, store } from '@graphprotocol/graph-ts'
+import { Edition, Ask } from "../types/schema"
 
 export function handleAskCreated (event: AskCreated):void {
 
+  let id = `${event.params.tokenContract.toHexString()}-${event.params.tokenId.toString()}`
   // check nft is an olta edition
-  const edition = Edition.load(`${event.params.tokenContract.toHexString()}-${event.params.tokenId.toString()}`)
+  let edition = Edition.load(id)
   if(edition === null) {
     return
   }
 
-  let id = event.transaction.hash.toHexString()
   log.info(`Starting handler for AskCreated {}`, [id])
 
-  const ask = findOrCreateAsk(id)
-  const currency = findOrCreateCurrency(event.params.ask.askCurrency.toHexString())
+  let ask = findOrCreateAsk(id)
+  let currency = findOrCreateCurrency(event.params.ask.askCurrency.toHexString())
 
   ask.price = event.params.ask.askPrice
   ask.currency = currency.id
@@ -28,6 +28,52 @@ export function handleAskCreated (event: AskCreated):void {
 
   log.info(`Completed handler for AskCreated {}`, [id])
 }
-export function handleAskPriceUpdated (event: AskPriceUpdated):void {}
-export function handleAskCanceled (event: AskCanceled):void {}
-export function handleAskFilled (event: AskFilled):void {}
+export function handleAskPriceUpdated (event: AskPriceUpdated):void {
+  let id = `${event.params.tokenContract.toHexString()}-${event.params.tokenId.toString()}`
+  // check ask is for an olta edition
+  let ask = Ask.load(id)
+  if(ask === null){
+    return
+  }
+
+  let currency = findOrCreateCurrency(event.params.ask.askCurrency.toHexString())
+
+  ask.price = event.params.ask.askPrice
+  ask.currency = currency.id
+
+  ask.save()
+}
+
+export function handleAskCanceled (event: AskCanceled):void {
+  let id = `${event.params.tokenContract.toHexString()}-${event.params.tokenId.toString()}`
+  // check ask is for an olta edition
+  let ask = Ask.load(id)
+  if(ask === null){
+    return
+  }
+
+  store.remove("Ask", id)
+}
+
+export function handleAskFilled (event: AskFilled):void {
+  let id = `${event.params.tokenContract.toHexString()}-${event.params.tokenId.toString()}`
+  // check ask is for an olta edition
+  let ask = Ask.load(id)
+  if(ask === null){
+    return
+  }
+
+  const collector = findOrCreateUser(event.params.buyer.toHexString())
+
+  ask.collector = collector.id
+  ask.status = "Filled"
+  ask.filledAtTimestamp = event.block.timestamp
+  ask.filledAtBlockNumber = event.block.number
+
+  // archive ask by appending the transaction hash to id
+  ask.id = id + "-" + event.transaction.hash.toHexString()
+  ask.save()
+
+  // remove left over ask
+  store.remove("Ask", id)
+}

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -79,6 +79,40 @@ dataSources:
       eventHandlers:
         - event: Updated(address,(string,string,string,string))
           handler: handleProfileUpdated
+  - kind: ethereum/contract
+    name: AsksV1_1
+    network: {{ network }}
+    source:
+      address: "{{ zoraAsksAddress }}"
+      abi: AsksV1_1
+      startBlock: {{ startBlock }}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/zoraAsks.ts
+      abis:
+        - name: AsksV1_1
+          file: ./abis/Zora/AsksV1_1.json
+        - name: ERC20
+          file: ./abis/ERC20/ERC20.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20/ERC20SymbolBytes.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20/ERC20NameBytes.json
+      entities:
+        - Ask
+        - Transfer
+        - Currency
+      eventHandlers:
+        - event: AskCreated(indexed address,indexed uint256,(address,address,address,uint16,uint256))
+          handler: handleAskCreated
+        - event: AskPriceUpdated(indexed address,indexed uint256,(address,address,address,uint16,uint256))
+          handler: handleAskPriceUpdated
+        - event: AskCanceled(indexed address,indexed uint256,(address,address,address,uint16,uint256))
+          handler: handleAskCanceled
+        - event: AskFilled(indexed address,indexed uint256,indexed address,address,(address,address,address,uint16,uint256))
+          handler: handleAskFilled
 templates:
   - name: StandardProject
     kind: ethereum/contract


### PR DESCRIPTION
Adds zora's asksV1_1 to the subgraph.

Adds ask entity and handles the `AskCreated`, `AskPriceUpdated`, `AskCanceled` and `AskFilled` events.

One quirk is that keeping track of the ask across all events can be difficult as there isn't a id given on the contract. I went for constructing the id from `projectContractAddress` and `EditionNumber`. Then once the ask has been filled append the `transaction hash` to the id and change the status to "Filled". This then free's up the id for future asks and as there is only ever one ask per edition this makes sense.

As a bonus the filled ask id matches the id of the resulting `transfer` entity making it somewhat easy to locate.

resolves #43

