### PR TITLE
Handle mistakes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -87,7 +87,7 @@ type Project @entity {
   createdAtBlockNumber: BigInt!
 
   "The timestamp of the block the Project was removed in"
-  removedAtTimeStamp: BigInt!
+  removedAtTimestamp: BigInt!
 
   "The number of the block the Project was removed in"
   removedAtBlockNumber: BigInt!
@@ -232,10 +232,10 @@ type Edition @entity {
   transfers: [Transfer!]! @derivedFrom(field: "edition")
 
   "The timestamp of the block the edition was burned in"
-  burnedAtTimeStamp: BigInt
+  burnedAtTimeStamp: BigInt!
 
   "The number of the block the edition was burned in"
-  burnedAtBlockNumber: BigInt
+  burnedAtBlockNumber: BigInt!
 
   "The approved user of the edition"
   approved: User

--- a/schema.graphql
+++ b/schema.graphql
@@ -80,11 +80,17 @@ type Project @entity {
   "The editions minted"
   editions: [Edition!] @derivedFrom(field: "project")
 
-  "The timestamp of the block the Purchase was created in"
+  "The timestamp of the block the Project was created in"
   createdAtTimestamp: BigInt!
 
-  "The number of the block the Purchase was created in"
+  "The number of the block the Project was created in"
   createdAtBlockNumber: BigInt!
+
+  "The timestamp of the block the Project was removed in"
+  removedAtTimeStamp: BigInt!
+
+  "The number of the block the Project was removed in"
+  removedAtBlockNumber: BigInt!
 
   "The dutch auction drops associated with this project"
   dutchAuctionDrops: [DutchAuctionDrop!] @derivedFrom(field: "project")

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -123,6 +123,12 @@ export const getEventArguments = async (tx: ContractTransaction, eventName: stri
   return event?.args!
 }
 
+// Helper to make sure timestamp is inline with hardhat node
+const getBlockTimestamp = async () => {
+  const { timestamp } = await network.provider.send("eth_getBlockByNumber", ["latest", false])
+  return parseInt(timestamp)
+}
+
 const createProject = async (signer: SignerWithAddress, SingleEditonCreator: ProjectCreator) => {
   const transaction = await SingleEditonCreator.connect(signer).createProject(
     editionData(
@@ -357,9 +363,58 @@ const run = async () => {
     console.log(`${count.increment()} creator set royalty fund recipient to curator`, tx.hash)
   }
 
+  // Make sure timestamp is inline with hardhat
+  const t = await getBlockTimestamp()
+
+  // create another project and cancel the auction
+  const project2 = await createProject(creator, SingleEditonCreator)
+  tx = await createAuction(
+    creator,
+    project2,
+    DutchAuctionDrop,
+    WETH,
+    {
+      editionContract: {
+        id: project2.address,
+        implementation: Implementation.editions
+      },
+      startTime: t + 120 // starts in 2 mins
+    }
+  )
+
+  await tx.wait()
+
+  const [auctionId2] = await getEventArguments(tx, "AuctionCreated")
+
+  tx = await DutchAuctionDrop.connect(creator).cancelAuction(auctionId2)
+  console.log(`${count.increment()} creator canceled auction:${auctionId2}`, tx.hash)
+
+  // create another auction for same project
+  tx = await createAuction(
+    creator,
+    project2,
+    DutchAuctionDrop,
+    WETH,
+    {
+      editionContract: {
+        id: project2.address,
+        implementation: Implementation.editions
+      },
+      startTime: t + 120 // starts in 2 mins
+    }
+  )
+
+  const [auctionId3] = await getEventArguments(tx, "AuctionCreated")
+  console.log(`${count.increment()} creator created another auction:${auctionId3}`, tx.hash)
+
+
   // mine an hour in time
   // NOTE[george]: this is a precution if the seed script has already been run
   await mineOneHour()
+
+  // end the first auction
+  tx = await DutchAuctionDrop.connect(creator).endAuction(auctionId)
+  console.log(`${count.increment()} creator ended auction:${auctionId}`, tx.hash)
 
   // add creator profile
   await Profiles.connect(creator).update({

--- a/src/dutchAuctionDrop.ts
+++ b/src/dutchAuctionDrop.ts
@@ -2,7 +2,9 @@ import {
   AuctionCreated,
   AuctionApprovalUpdated,
   EditionPurchased,
-  SeededEditionPurchased
+  SeededEditionPurchased,
+  AuctionCanceled,
+  AuctionEnded
 } from '../types/DutchAuctionDrop/DutchAuctionDrop'
 
 import {
@@ -90,6 +92,42 @@ export function handleSeededEditionPurchased(event: SeededEditionPurchased): voi
   createPurchase(event, id)
 
   log.info(`Completed handler for SeededEditionPurchased on auction {}`, [id])
+}
+
+export function handleAuctionCanceled(event: AuctionCanceled): void {
+  const id = event.params.auctionId.toString()
+  log.info(`Starting handler for AuctionCanceled on auction {}`, [id])
+
+  let auction = DutchAuctionDrop.load(id)
+
+  if(auction == null) {
+    log.error('Missing Auction with id {} for approval', [id])
+    return
+  }
+
+  auction.status = "Canceled"
+  auction.save()
+
+  log.info(`Completed handler for AuctionCanceled on auction {}`, [id])
+}
+
+export function handleAuctionEnded(event: AuctionEnded): void {
+  const id = event.params.auctionId.toString()
+  log.info(`Starting handler for AuctionEnded on auction {}`, [id])
+
+  let auction = DutchAuctionDrop.load(id)
+
+  if(auction == null) {
+    log.error('Missing Auction with id {} for approval', [id])
+    return
+  }
+
+  auction.finalizedAtTimestamp = event.block.timestamp
+  auction.finalizedAtBlockNumber = event.block.number
+  auction.status = "Finished"
+  auction.save()
+
+  log.info(`Completed handler for AuctionEnded on auction {}`, [id])
 }
 
 function createPurchase<T extends EditionPurchased>(event: T, id: string): void {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -238,7 +238,7 @@ export function createDutchAuctionDrop(
  export function fetchCurrencyDecimals(currencyAddress: Address): i32 {
   let contract = ERC20.bind(currencyAddress)
   // try types uint8 for decimals
-  let decimalValue = null
+  let decimalValue = 0
   let decimalResult = contract.try_decimals()
   if (!decimalResult.reverted) {
     decimalValue = decimalResult.value

--- a/src/projectHandlers.ts
+++ b/src/projectHandlers.ts
@@ -166,7 +166,7 @@ function burnHandler<T extends Transfer>(event: T, context: DataSourceContext): 
   project.totalSupply = project.totalSupply.minus(BigInt.fromI32(1))
 
   if(project.totalBurned.equals(project.totalSupply)){
-    project.removedAtTimeStamp = event.block.timestamp
+    project.removedAtTimestamp = event.block.timestamp
     project.removedAtBlockNumber = event.block.number
   }
 

--- a/src/projectHandlers.ts
+++ b/src/projectHandlers.ts
@@ -164,6 +164,12 @@ function burnHandler<T extends Transfer>(event: T, context: DataSourceContext): 
   let project = findOrCreateProject(context.getString('project'))
   project.totalBurned = project.totalBurned.plus(BigInt.fromI32(1))
   project.totalSupply = project.totalSupply.minus(BigInt.fromI32(1))
+
+  if(project.totalBurned.equals(project.totalSupply)){
+    project.removedAtTimeStamp = event.block.timestamp
+    project.removedAtBlockNumber = event.block.number
+  }
+
   project.save()
 
   log.info(`Completed handler for Burn for edition {}`, [id])
@@ -372,21 +378,4 @@ function isSplitWallet(split: Address): boolean {
     if(hashResult.value.toHexString() === zeroAddress) return false
   */
   return true
-}
-
-export function ownershipTransferredHandler<T extends OwnershipTransferred>(event: T, context: DataSourceContext): void {
-  const projectId = context.getString('project')
-
-  log.info(`Starting: handler for OwnershipTransferred for project {}`, [projectId])
-
-  if(event.params.newOwner.toHexString() === zeroAddress){
-    let project = findOrCreateProject(projectId)
-
-    project.removedAtTimeStamp = event.block.timestamp
-    project.removedAtBlockNumber = event.block.number
-
-    project.save()
-  }
-
-  log.info(`Completed: handler for OwnershipTransferred for project {}`, [projectId])
 }

--- a/src/projectHandlers.ts
+++ b/src/projectHandlers.ts
@@ -7,6 +7,7 @@ import {
   Approval,
   ApprovedMinter,
   RoyaltyFundsRecipientChanged,
+  OwnershipTransferred
 } from '../types/templates/StandardProject/StandardProject'
 
 import {
@@ -371,4 +372,21 @@ function isSplitWallet(split: Address): boolean {
     if(hashResult.value.toHexString() === zeroAddress) return false
   */
   return true
+}
+
+export function ownershipTransferredHandler<T extends OwnershipTransferred>(event: T, context: DataSourceContext): void {
+  const projectId = context.getString('project')
+
+  log.info(`Starting: handler for OwnershipTransferred for project {}`, [projectId])
+
+  if(event.params.newOwner.toHexString() === zeroAddress){
+    let project = findOrCreateProject(projectId)
+
+    project.removedAtTimeStamp = event.block.timestamp
+    project.removedAtBlockNumber = event.block.number
+
+    project.save()
+  }
+
+  log.info(`Completed: handler for OwnershipTransferred for project {}`, [projectId])
 }

--- a/src/seededProject.ts
+++ b/src/seededProject.ts
@@ -7,7 +7,6 @@ import {
   Approval,
   ApprovedMinter,
   RoyaltyFundsRecipientChanged,
-  OwnershipTransferred
 } from '../types/templates/SeededProject/SeededProject'
 
 import {
@@ -16,8 +15,7 @@ import {
   approvalHandler,
   versionAddedHandler,
   versionURLUpdatedHandler,
-  royaltyFundsRecipientChangedHandler,
-  ownershipTransferredHandler
+  royaltyFundsRecipientChangedHandler
  } from './projectHandlers'
 
 let context = dataSource.context()
@@ -28,4 +26,3 @@ export function handleApproval(event: Approval): void { approvalHandler(event, c
 export function handleVersionAdded(event: VersionAdded): void { versionAddedHandler(event, context) }
 export function handleVersionURLUpdated(event: VersionURLUpdated): void { versionURLUpdatedHandler(event, context) }
 export function handleRoyaltyFundsRecipientChanged(event: RoyaltyFundsRecipientChanged): void { royaltyFundsRecipientChangedHandler(event, context)}
-export function handleOwnershipTransferred(event: OwnershipTransferred): void {ownershipTransferredHandler(event, context)}

--- a/src/seededProject.ts
+++ b/src/seededProject.ts
@@ -6,7 +6,8 @@ import {
   VersionURLUpdated,
   Approval,
   ApprovedMinter,
-  RoyaltyFundsRecipientChanged
+  RoyaltyFundsRecipientChanged,
+  OwnershipTransferred
 } from '../types/templates/SeededProject/SeededProject'
 
 import {
@@ -15,7 +16,8 @@ import {
   approvalHandler,
   versionAddedHandler,
   versionURLUpdatedHandler,
-  royaltyFundsRecipientChangedHandler
+  royaltyFundsRecipientChangedHandler,
+  ownershipTransferredHandler
  } from './projectHandlers'
 
 let context = dataSource.context()
@@ -26,3 +28,4 @@ export function handleApproval(event: Approval): void { approvalHandler(event, c
 export function handleVersionAdded(event: VersionAdded): void { versionAddedHandler(event, context) }
 export function handleVersionURLUpdated(event: VersionURLUpdated): void { versionURLUpdatedHandler(event, context) }
 export function handleRoyaltyFundsRecipientChanged(event: RoyaltyFundsRecipientChanged): void { royaltyFundsRecipientChangedHandler(event, context)}
+export function handleOwnershipTransferred(event: OwnershipTransferred): void {ownershipTransferredHandler(event, context)}

--- a/src/standardProject.ts
+++ b/src/standardProject.ts
@@ -6,8 +6,7 @@ import {
   VersionURLUpdated,
   Approval,
   ApprovedMinter,
-  RoyaltyFundsRecipientChanged,
-  OwnershipTransferred
+  RoyaltyFundsRecipientChanged
 } from '../types/templates/StandardProject/StandardProject'
 
 import {
@@ -17,7 +16,6 @@ import {
   versionAddedHandler,
   versionURLUpdatedHandler,
   royaltyFundsRecipientChangedHandler,
-  ownershipTransferredHandler
  } from './projectHandlers'
 
 let context = dataSource.context()
@@ -28,4 +26,3 @@ export function handleApproval(event: Approval): void { approvalHandler(event, c
 export function handleVersionAdded(event: VersionAdded): void { versionAddedHandler(event, context) }
 export function handleVersionURLUpdated(event: VersionURLUpdated): void { versionURLUpdatedHandler(event, context) }
 export function handleRoyaltyFundsRecipientChanged(event: RoyaltyFundsRecipientChanged): void { royaltyFundsRecipientChangedHandler(event, context)}
-export function handleOwnershipTransferred(event: OwnershipTransferred): void {ownershipTransferredHandler(event, context)}

--- a/src/standardProject.ts
+++ b/src/standardProject.ts
@@ -6,7 +6,8 @@ import {
   VersionURLUpdated,
   Approval,
   ApprovedMinter,
-  RoyaltyFundsRecipientChanged
+  RoyaltyFundsRecipientChanged,
+  OwnershipTransferred
 } from '../types/templates/StandardProject/StandardProject'
 
 import {
@@ -15,7 +16,8 @@ import {
   approvalHandler,
   versionAddedHandler,
   versionURLUpdatedHandler,
-  royaltyFundsRecipientChangedHandler
+  royaltyFundsRecipientChangedHandler,
+  ownershipTransferredHandler
  } from './projectHandlers'
 
 let context = dataSource.context()
@@ -26,3 +28,4 @@ export function handleApproval(event: Approval): void { approvalHandler(event, c
 export function handleVersionAdded(event: VersionAdded): void { versionAddedHandler(event, context) }
 export function handleVersionURLUpdated(event: VersionURLUpdated): void { versionURLUpdatedHandler(event, context) }
 export function handleRoyaltyFundsRecipientChanged(event: RoyaltyFundsRecipientChanged): void { royaltyFundsRecipientChangedHandler(event, context)}
+export function handleOwnershipTransferred(event: OwnershipTransferred): void {ownershipTransferredHandler(event, context)}

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -154,8 +154,6 @@ templates:
           handler: handleApprovedMinter
         - event: RoyaltyFundsRecipientChanged(address)
           handler: handleRoyaltyFundsRecipientChanged
-        - event: OwnershipTransferred(indexed address,indexed address)
-          handler: handleOwnershipTransferred
         # TODO: set price sale eth
         # TODO: other erc-721 events
       file: ./src/standardProject.ts
@@ -195,8 +193,6 @@ templates:
           handler: handleApprovedMinter
         - event: RoyaltyFundsRecipientChanged(address)
           handler: handleRoyaltyFundsRecipientChanged
-        - event: OwnershipTransferred(indexed address,indexed address)
-          handler: handleOwnershipTransferred
         # TODO: set price sale eth
         # TODO: other erc-721 events
       file: ./src/seededProject.ts

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -36,6 +36,10 @@ dataSources:
           handler: handleSeededEditionPurchased
         - event: AuctionApprovalUpdated(uint256,address,bool)
           handler: handleAuctionApprovalUpdated
+        - event: AuctionCanceled(uint256,address)
+          handler: handleAuctionCanceled
+        - event: AuctionEnded(uint256,address)
+          handler: handleAuctionEnded
       file: ./src/dutchAuctionDrop.ts
   - kind: ethereum/contract
     name: ProjectCreator

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -150,6 +150,8 @@ templates:
           handler: handleApprovedMinter
         - event: RoyaltyFundsRecipientChanged(address)
           handler: handleRoyaltyFundsRecipientChanged
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleOwnershipTransferred
         # TODO: set price sale eth
         # TODO: other erc-721 events
       file: ./src/standardProject.ts
@@ -189,6 +191,8 @@ templates:
           handler: handleApprovedMinter
         - event: RoyaltyFundsRecipientChanged(address)
           handler: handleRoyaltyFundsRecipientChanged
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleOwnershipTransferred
         # TODO: set price sale eth
         # TODO: other erc-721 events
       file: ./src/seededProject.ts


### PR DESCRIPTION
resolves #9

## auction canceled
when an auction is canceled it's `status` is set to `"Canceled"`

## auction ended
when a auction is ended `finalizedAtBlock` and `finalizedAtTimestamp` are set. As well as `status` is set to `"Finished"`

---

## project removed
When all editions of a project are burned `removedAtBlock` and `removedAtTimestamp` are set on the project.

also fixes the null compiler bug for currency decimals by setting it to 0 instead of null





